### PR TITLE
規約の分離：TypeScript と GitHub Actions

### DIFF
--- a/agent_template/rules/11_typescript.md
+++ b/agent_template/rules/11_typescript.md
@@ -1,6 +1,6 @@
-# TypeScript / GitHub Actions 規約 [11_typescript.md]
+# TypeScript 規約 [11_typescript.md]
 
-TypeScript および GitHub Actions (JavaScript/TypeScript 基盤のカスタムアクション) 開発における統一ルールです。
+TypeScript 開発における、型安全性とコード品質を担保するための統一ルールです。
 
 ## 1. コーディング規約
 
@@ -11,26 +11,17 @@ TypeScript および GitHub Actions (JavaScript/TypeScript 基盤のカスタム
   - `eslint` および `prettier` が導入されている場合、必ずこれらを実行してコード品質を担保してください。
   - コミット前に `npm run lint` や `npm run format` (または相当するコマンド) を実行してください。
 
-## 2. GitHub Actions (Custom Action) 開発
-
-- **metadata**: `action.yml` (または `action.yaml`) のメタデータを最新の状態に保ってください。
-- **dist 配布**:
-  - `ncc` 等でビルドした成果物をリポジトリに含める構成の場合、ソースコードの修正に合わせて必ずビルドを行い、成果物を更新してください。
-- **検証**:
-  - `npm test` 等でユニットテストが用意されている場合、必ずパスすることを確認してください。
-
-## 3. 許可されているコマンド (SafeToAutoRun: true)
+## 2. 許可されているコマンド (SafeToAutoRun: true)
 
 - `npm install`, `yarn install`, `pnpm install`
 - `npm run build`, `npm run test`, `npm run lint`
 - `tsc --noEmit`
 - `ls`, `cat`, `dir` (情報取得)
 
-## 4. 実装完了後の必須検証
+## 3. 実装完了後の必須検証
 
 タスク完了を宣言する前に、以下の項目を確認してください。
 
 1. [ ] ビルドエラーおよび型エラーがないこと
 2. [ ] ユニットテストがすべてパスすること
 3. [ ] Lint エラーがないこと
-4. [ ] (成果物配布型の場合) `dist/` 等の成果物が最新であること

--- a/agent_template/rules/13_github_actions.md
+++ b/agent_template/rules/13_github_actions.md
@@ -1,0 +1,30 @@
+# GitHub Actions 規約 [13_github_actions.md]
+
+GitHub Actions (ワークフローおよび JavaScript/TypeScript 基盤のカスタムアクション) 開発における統一ルールです。
+
+## 1. GitHub Actions (Custom Action) 開発
+
+- **metadata**: `action.yml` (または `action.yaml`) のメタデータを最新の状態に保ってください。
+- **dist 配布**:
+  - `ncc` 等でビルドした成果物をリポジトリに含める構成の場合、ソースコードの修正に合わせて必ずビルドを行い、成果物を更新してください。
+- **検証**:
+  - `npm test` 等でユニットテストが用意されている場合、必ずパスすることを確認してください。
+
+## 2. ワークフロー定義
+
+- **セキュリティ**: `secrets` の扱い、および `permissions` 設定を最小権限の原則 (Least Privilege) に基づいて構成してください。
+- **再利用性**: 共通処理がある場合は、Composite Action や Reusable Workflow の活用を検討してください。
+
+## 3. 許可されているコマンド (SafeToAutoRun: true)
+
+- `gh` コマンド全般 (PR, Issue, Workflow 操作)
+- `ls`, `cat`, `dir` (情報取得)
+
+## 4. 実装完了後の必須検証
+
+タスク完了を宣言する前に、以下の項目を確認してください。
+
+1. [ ] `action.yml` の定義とソースコードに不整合がないこと
+2. [ ] (成果物配布型の場合) `dist/` 等の成果物が最新であること
+3. [ ] ユニットテストがすべてパスすること
+4. [ ] ワークフローの YAML シンタックスエラーがないこと

--- a/antigravityrule.template
+++ b/antigravityrule.template
@@ -47,10 +47,15 @@ Failure to include this phrase at the very beginning of your response is UNACCEP
 - **内容**: Kotlin / Compose 規約、必須検証手順 (assembleDebug, testDebugUnitTest 等)
 - **削除条件**: プロジェクトが Android アプリケーションでない場合、この項目を削除してください。
 
-#### [TypeScript] TypeScript / GitHub Actions 開発規約
+#### [TypeScript] TypeScript 開発規約
 - **パス**: `.agent/rules/11_typescript.md`
-- **内容**: TypeScript 規約、GitHub Actions (Custom Action) 開発手順、npm/yarn 操作
+- **内容**: TypeScript コード品質、Lint/Format、型定義、テスト
 - **削除条件**: プロジェクトが TypeScript/JavaScript をメインとしていない場合、この項目を削除してください。
+
+#### [GitHub Actions] GitHub Actions 開発規約
+- **パス**: `.agent/rules/13_github_actions.md`
+- **内容**: ワークフロー定義、Custom Action (JavaScript/TypeScript 基盤) 開発、セキュリティ
+- **削除条件**: プロジェクトが GitHub Actions ワークフローやカスタムアクションをメインとしていない場合、この項目を削除してください。
 
 #### [Python] Python / Scraping 開発規約
 - **パス**: `.agent/rules/12_python.md`
@@ -67,5 +72,6 @@ rules:
   - .agent/rules/10_android.md
   - .agent/rules/11_typescript.md
   - .agent/rules/12_python.md
+  - .agent/rules/13_github_actions.md
   - .agent/rules/auto-commands.yaml
 ```


### PR DESCRIPTION
## 内容 (Summary)
TypeScript 言語規約と GitHub Actions 開発規約を別ファイルに分離し、プロジェクトの種類に応じて適用するルールを最適化できるようにしました。
Resolves #12

## 変更点 (Changes)
- agent_template/rules/11_typescript.md を TypeScript 言語規約に特化
- agent_template/rules/13_github_actions.md を新設（Actions ワークフロー・カスタムアクション開発用）
- antigravityrule.template のインデックスを更新

## 確認事項 (Verification)
- [x] 各 md ファイルが正しい関心事に分かれていること
- [x] テンプレートのインデックスから各ファイルが参照可能であること
