### PR TITLE
auto-commands.yaml に頻出する安全な引数付きコマンドと一時ファイルアクセス権限を追加

### DIFF
--- a/.agent/rules/auto-commands.yaml
+++ b/.agent/rules/auto-commands.yaml
@@ -21,7 +21,10 @@ git:
   description: "Git 読み取り操作および 02_git.md の規定に基づく自律的操作"
   commands:
     - git status
+    - git status --porcelain
     - git branch
+    - git branch -a
+    - git branch --show-current
     - git log
     - git diff
     - git show
@@ -33,7 +36,7 @@ git:
     - git checkout
 
 github_cli:
-  description: "GitHub CLI を用いた進捗確認・情報取得"
+  description: "GitHub CLI を用いた進捗確認・情報取得・一時ファイルを利用した更新（SafeToAutoRun: true）"
   commands:
     - gh auth status
     - gh issue list
@@ -41,6 +44,14 @@ github_cli:
     - gh pr list
     - gh pr view
     - gh repo view
+    - gh issue create --body-file temp/*
+    - gh issue create --body-file temp\*
+    - gh issue edit --body-file temp/*
+    - gh issue edit --body-file temp\*
+    - gh pr create --body-file temp/*
+    - gh pr create --body-file temp\*
+    - gh pr edit --body-file temp/*
+    - gh pr edit --body-file temp\*
 
 development_stacks:
   android:


### PR DESCRIPTION
## 内容 (Summary)
`auto-commands.yaml` のホワイトリストを拡張し、AIが常用する安全なコマンド・引数の組み合わせを明記しました。
Closes #20

## 変更点 (Changes)
- `git branch` や `git status` に対して、`--show-current` や `-a`, `--porcelain` などの頻出オプションを含めた完全な形で許可コマンドを追加
- GitHub CLI (`gh issue/pr create/edit`) に対して、`--body-file temp/*` オプションを使用したコマンドを追加

## 確認事項 (Verification)
- [x] YAML 形式として妥当な構造になっているか
- [x] 追加されたコマンドが副作用のない読み取り専用、または一時ファイルに対する正規の操作であるか
