### PR TITLE
状態遷移表の最適化（マージ完了後は PLANNING へ）

### DIFF
--- a/.agent/rules/01_workflow.md
+++ b/.agent/rules/01_workflow.md
@@ -20,9 +20,8 @@
 | **`ACTIVE`** | `PLANNING` | **対象 Issue 等の確定** | `ACTIVE` | `PREPARING` | `flow-kickoff` の実行へ移行 |
 | **`ACTIVE`** | `PREPARING` | **`flow-kickoff` 完了** | `ACTIVE` | `DEVELOPING` | Draft PRが作成され、実装を開始 |
 | **`ACTIVE`** | `DEVELOPING` | **`flow-wrapup` 完了** | `ACTIVE` | `REVIEWING` | 自動検証パス、PR が Ready 状態 |
-| **`ACTIVE`** | `REVIEWING` | **マージ完了 ＆ `/cleanup`** | `ACTIVE` | `PLANNING` | 次のタスクの計画フェーズへ戻る |
-| **`ACTIVE`** | *Any* | **`/dev-pause` （中断・栞）** | **`IDLE`** | **`-`** | 栞を残してエージェントが待機 |
-| **`ACTIVE`** | `REVIEWING` | **マージ完了（次タスクなし）** | **`IDLE`** | **`-`** | プロジェクトの全フェーズ完了時 |
+| **`ACTIVE`** | `REVIEWING` | **マージ完了 ＆ `/cleanup`** | `ACTIVE` | `PLANNING` | 次のタスク計画、または「次どうする？」の相談へ戻る |
+| **`ACTIVE`** | *Any* | **`/dev-pause` （中断・栞）** | **`IDLE`** | **`-`** | 栞を残してエージェントが待機（セッション中断） |
 
 ---
 


### PR DESCRIPTION
## 概要 (Summary)
`01_workflow.md` の状態遷移表において、マージ完了時の遷移をすべて `PLANNING` に統一し、`IDLE` へ移行するトリガーを `/dev-pause`（栞の保存）時のみに限定することで、セッションの連続性を向上させました。

## 関連 Issue (Related Issue)
- Closes #44

## 変更内容 (Changes)
- [x] `01_workflow.md` の状態遷移表から、最下段の「マージ完了（次タスクなし）」の行を削除。
- [x] マージ完了時の遷移先を `PLANNING`（ACTIVE）に集約。

## 確認事項 (Verification)
- [x] 構文エラーおよび実行時エラーがないことを確認した
- [x] `docs/status/roadmap.md` が最新の状態に更新されている（該当なし）
- [x] コミットメッセージのフォーマットが適切であること
- [x] PR が **Ready for review** (Draft 解除済み) であることを確認した
- [x] 不要なデバッグ用コードやログが残っていない
