### PR TITLE
マニュアル（docs/workflow/README.md）へのバックログ運用の追記

### DIFF
--- a/docs/workflow/README.md
+++ b/docs/workflow/README.md
@@ -23,6 +23,15 @@
 
 ユーザー（あなた）は大まかな方向だけを指示し、コマンドの詳細や安全性の検証は AI がスキル（自動操縦マニュアル）を読み込んで自律的に実施します。
 
+### 📥 2-A. アイデア・要望の出し方 (`backlog.md`)
+
+ユーザー（あなた）が「将来的にやりたいこと」や「ざっくりしたアイデア」を思いついたときは、**`docs/status/backlog.md`** に箇条書きでメモを残してください。
+
+- **書き場所**: 「📥 未分類の要望 (Unsorted Ideas)」の最下部
+- **AI の挙動**: エージェントは `PLANNING` フェーズでこのファイルを自動的にチェックし、要件定義とタスク分解を挟んで `roadmap.md`（ロードマップ）へ反映・提案します。
+
+---
+
 ### 📊 モードと状態遷移 (State Transitions)
 
 ```mermaid
@@ -75,5 +84,5 @@ stateDiagram-v2
 │   └── workflows/         <-- Slash コマンド群 (/dev-pause, /dev-start, /cleanup 等)
 ├── .github/               <-- 共通 Issue テンプレート等
 ├── .vscode/               <-- VS Code 設定 (autoApprove 設定含む)
-└── docs/status/           <-- 進捗管理 (roadmap.md)
+└── docs/status/           <-- 進捗管理 (roadmap.md, backlog.md)
 ```


### PR DESCRIPTION
## 概要 (Summary)
ユーザー向けマニュアルである `docs/workflow/README.md` に、新設した `docs/status/backlog.md` の使い方を追記しました。

## 関連 Issue (Related Issue)
- Closes #48

## 変更内容 (Changes)
- [x] `docs/workflow/README.md` にセクション「📥 2-A. アイデア・要望の出し方」を追加
- [x] ディレクトリ構造図に `backlog.md` を追記

## 確認事項 (Verification)
- [x] 構文エラーおよび実行時エラーがないことを確認した
- [x] 自動検証（`verify-pr.ps1`）をパスし、Ready 状態で提出しています
