### PR TITLE
マニュアル（docs/workflow/README.md）への skills 追記

### DIFF
--- a/docs/workflow/README.md
+++ b/docs/workflow/README.md
@@ -72,7 +72,8 @@ stateDiagram-v2
 │   ├── rules/             <-- 共通規約 (/sync-workflow で同期される)
 │   ├── custom/            <-- 各プロジェクト固有規約 (同期対象外)
 │   ├── templates/         <-- Issue / PR 向けのテンプレート群
-│   └── workflows/         <-- Slash コマンド群 (/dev-pause, /dev-start, /cleanup 等)
+│   ├── workflows/         <-- Slash コマンド群 (/dev-pause, /dev-start, /cleanup 等)
+│   └── skills/            <-- 各種タスクの自律実行手順 (flow-kickoff, github-pr 等)
 ├── .github/               <-- 共通 Issue テンプレート等
 ├── .vscode/               <-- VS Code 設定 (autoApprove 設定含む)
 └── docs/status/           <-- 進捗管理 (roadmap.md)


### PR DESCRIPTION
## 概要 (Summary)
ユーザー向けマニュアルである `docs/workflow/README.md` の「DIRECTORY STRUCTURE」セクションにおいて、`.agent/skills/` ディレクトリ（自律実行手順）の記述が抜けていたため、追記しました。

## 関連 Issue (Related Issue)
- Closes #50

## 変更内容 (Changes)
- [x] ディレクトリ構造図の `.agent/` 配下に `skills/` を追加し、役割を記載。

## 確認事項 (Verification)
- [x] 構文エラーおよび実行時エラーがないことを確認した
- [x] 自動検証（`verify-pr.ps1`）をパスし、Ready 状態で提出しています
