### PR TITLE
ルート README.md のリファクタリング（機能紹介への特化）

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,79 +1,31 @@
 # antigravity-workflow
 
-このリポジトリは、AI エージェント Antigravity が GitHub 上で自律的に開発を実行するための標準ワークフロー（GitHub flow 準拠）と設定を提供する基盤です。
+AI エージェントと創る、安全で自律的な開発ワークフロー基盤。
+
+このリポジトリは、AI エージェント（Antigravity等）が GitHub 上で自律的に、かつ安全に開発を進行するための標準ワークフロー（GitHub flow 準拠）と設定を提供するフレームワークです。
 
 ---
 
-## 🛠️ 1. 初期セットアップ方法 (Initial Setup)
+## ✨ 1. 主な特徴 (Features)
 
-新しいプロジェクトにこの開発ワークフローを導入する手順です。
-
-1. **ワークフローファイルのコピー**:
-   - 本リポジトリの `.agent/workflows/setup-workflow.md` を、対象プロジェクトの `.agent/workflows/setup-workflow.md` へコピーします。
-2. **AI エージェントへの指示**:
-   - チャットで **`/setup-workflow`** の実行を指示してください。
-   - ※自動的に最新の共通規約、Git フック、GitHub ラベル等がインストール・構成されます。
-
-> [!TIP]
-> 導入後は、**`/sync-workflow`** を定期的に実行するだけで、本リポジトリ側で改善された最新のワークフローを反映できます。
+- **🗂️ 連続性を保つ進捗管理**: `roadmap.md` や `backlog.md` による自律的なタスク管理。
+- **🛡️ 事故を防ぐ安全ガードレール**: 文字化け、誤コミット、Ready前報告を防ぐスキル（カプセル化）制御。
+- **🔄 厳格な状態管理**: エージェントの活性状態（`ACTIVE`/`IDLE`）を常に明確にし、開発ライフサイクルを一本道で繋ぎます。
+- **📦 同期可能な配信モデル**: `/sync-workflow` で最新の共通規約をスムーズに子リポジトリへ配信可能。
 
 ---
 
-## 🧭 2. 開発の進め方・指示の出し方 (Development Cycle)
+## 🚀 2. 使い方・導入方法 (Getting Started)
 
-ユーザー（あなた）は大まかな方向だけを指示し、コマンドの詳細や安全性の検証は AI がスキル（自動操縦マニュアル）を読み込んで自律的に実施します。
+このワークフローを自分のプロジェクトに導入する方法、および開発時の指示の出し方については、以下の**ユーザーガイド**をご覧ください。
 
-### 📊 モードと状態遷移 (State Transitions)
-
-```mermaid
-stateDiagram-v2
-    state "IDLE (通常チャット)" as Idle
-    state "ACTIVE (開発モード)   " as Active {
-        [*] --> Planning : ロードマップ確認
-        Planning --> Preparing : タスク確定・Issue起票
-        Preparing --> Developing : 早期 Draft PR 作成
-        Developing --> Reviewing : 最終検証 & gh pr ready
-        Reviewing --> Planning : マージ完了 /cleanup
-    }
-
-    [*] --> Idle
-    Idle --> Active: /dev-start (開発開始・再開)
-    Active --> Idle: /dev-pause (一時停止・保存)
-```
-
-### 🔄 基本的なサイクルと指示の例
-
-| フェーズ（状態） | あなた（ユーザー）の指示例 | AI エージェントの自律稼働 |
-| :--- | :--- | :--- |
-| **1. 計画・着手** | **`roadmap.md から次のタスクを選んで着手して`** | ・Issueの特定/新規起票<br>・ブランチ作成（Issue紐付け）<br>・空Commit ＆ **Draft PR** 作成 |
-| **2. 実装ループ** | ※通常は自律的に実装やテストを行います。<br>中断時: **/dev-pause** / 再開時: **/dev-start** | ・`task.md` での極小ステップ分解管理<br>・都度のテスト ＆ コミット<br>・中断時のCheckpoint（栞）投稿 |
-| **3. 最終化** | (実装ループが完了するとAIが報告します) | ・最終動作検証<br>・`roadmap.md` の完了マーク<br>・`gh pr ready` (Draft解除) |
-| **4. 後処理** | **/cleanup** | ・安全確認後のブランチ削除 |
+👉 **[マニュアル・利用ガイドはこちら (docs/workflow/README.md)](./docs/workflow/README.md)**
 
 ---
 
-## 🔧 3. ルールの更新・カスタマイズ (Customization)
+## 🤝 3. 開発への貢献 (Contributing)
 
-プロジェクト専用の言語・技術スタックに合わせたルールの追加方法です。
+このワークフロー基盤自体のルール改善や機能追加の提案・バグ報告は、Issue または Pull Request にて歓迎します。
 
-- **プロジェクト固有ルールの追加 (Custom)**:
-  - **`.agent/custom/`** 配下に Markdown（`.md`）で規約ファイルを配置してください。
-  - AI エージェントは自動的に読み込み、最優先の独自ルール（Local Context）として自動適用します。
-- **共通ルールの更新**:
-  - ルートの `.antigravityrule` や `.agent/rules/` の改善は、共通基盤へのフィードバック還元をお願いします。
-
----
-
-## 📂 ディレクトリ構造 (Structure)
-
-```text
-├── .antigravityrule       <-- AI エージェントの動作全体の指針とインデックス
-├── .agent/
-│   ├── rules/             <-- 共通規約 (/sync-workflow で同期される)
-│   ├── custom/            <-- 各プロジェクト固有規約 (同期対象外)
-│   ├── templates/         <-- Issue / PR 向けのテンプレート群
-│   └── workflows/         <-- Slash コマンド群 (/dev-pause, /dev-start, /cleanup 等)
-├── .github/               <-- 共通 Issue テンプレート等
-├── .vscode/               <-- VS Code 設定 (autoApprove 設定含む)
-└── docs/status/           <-- 進捗管理 (roadmap.md)
-```
+1. 新しいアイデアやバグは **Issue** で報告してください。
+2. 修正時は Issue に紐づくトピックブランチを作成し、PR を出してください。


### PR DESCRIPTION
## 概要 (Summary)
ルート `README.md` と `docs/workflow/README.md` の記述が重複していたため、ルート `README.md` を「機能紹介＆ポータル」に特化させ、詳細な使い方はマニュアルへリンクする形にリファクタリングしました。

## 関連 Issue (Related Issue)
- Closes #52

## 変更内容 (Changes)
- [x] ルート `README.md` からセットアップ等の詳細を削除し、マニュアル（`docs/workflow/README.md`）へのリンクに集約
- [x] 主な特徴（Features）や貢献方法（Contributing）への書き換え

## 確認事項 (Verification)
- [x] 構文エラーおよび実行時エラーがないことを確認した
- [x] 自動検証（`verify-pr.ps1`）をパスし、Ready 状態で提出しています
